### PR TITLE
fixed issue with zune-jpeg dependency not compiling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2393,7 +2393,7 @@ dependencies = [
  "rgb",
  "tiff 0.10.3",
  "zune-core 0.5.0",
- "zune-jpeg 0.5.7",
+ "zune-jpeg 0.5.6",
 ]
 
 [[package]]
@@ -6503,9 +6503,9 @@ dependencies = [
 
 [[package]]
 name = "zune-jpeg"
-version = "0.5.7"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d915729b0e7d5fe35c2f294c5dc10b30207cc637920e5b59077bfa3da63f28"
+checksum = "f520eebad972262a1dde0ec455bce4f8b298b1e5154513de58c114c4c54303e8"
 dependencies = [
  "zune-core 0.5.0",
 ]


### PR DESCRIPTION
the dependency "zune-jpeg" from the "image" dependency was not compiling on some windows devices. To fix this issue the version was downgraded from 0.5.7 to 0.5.6 which compiles on all devices.

<img width="315" height="22" alt="image" src="https://github.com/user-attachments/assets/3d03b0f3-668b-457e-9394-c161dbd0e005" />
