### PR TITLE
visual enhancements to workout creation and workout stays when you go to another tab

### DIFF
--- a/src/client/backend/exercise_manager.rs
+++ b/src/client/backend/exercise_manager.rs
@@ -216,7 +216,9 @@ impl ExerciseManager {
     }
 
     pub fn start_workout(&mut self) {
-        self.workout_in_creation = Some(Vec::new());
+        if self.workout_in_creation.is_none() {
+            self.workout_in_creation = Some(Vec::new());
+        }
     }
 
     pub fn get_last_done_set(&self, exercise: &String) -> Option<StrengthSet> {

--- a/src/client/gui/bb_tab/login.rs
+++ b/src/client/gui/bb_tab/login.rs
@@ -1,6 +1,5 @@
 use crate::client::gui::app::App;
-use crate::client::gui::bb_theme::color;
-use crate::client::gui::bb_theme::color::{ERROR_COLOR, TEXT_COLOR};
+use crate::client::gui::bb_theme::color::{BACKGROUND_COLOR, ERROR_COLOR, TEXT_COLOR};
 use crate::client::gui::bb_theme::combo_box::create_text_input_style;
 use crate::client::gui::bb_theme::container::{ContainerStyle, create_container_style};
 use crate::client::gui::bb_theme::custom_button::{ButtonStyle, create_element_button};
@@ -29,14 +28,20 @@ pub fn view_login(app: &App) -> Element<'_, Message> {
 
     let username_field: Element<Message> =
         text_input("Enter username...", &app.login_state.username)
-            .style(create_text_input_style(&app.mascot_manager.selected_mascot))
+            .style(create_text_input_style(
+                &app.mascot_manager.selected_mascot,
+                BACKGROUND_COLOR,
+            ))
             .font(FIRA_SANS_EXTRABOLD)
             .on_input(Message::UsernameEntered)
             .into();
 
     let password_field: Element<Message> =
         text_input("Enter password...", &app.login_state.password)
-            .style(create_text_input_style(&app.mascot_manager.selected_mascot))
+            .style(create_text_input_style(
+                &app.mascot_manager.selected_mascot,
+                BACKGROUND_COLOR,
+            ))
             .font(FIRA_SANS_EXTRABOLD)
             .on_input(Message::PasswordEntered)
             .on_submit(Message::TryLogin)
@@ -91,7 +96,7 @@ pub fn view_login(app: &App) -> Element<'_, Message> {
         .height(Fill)
         .style(|_theme: &Theme| container::Style {
             text_color: None,
-            background: Some(iced::Background::Color(color::BACKGROUND_COLOR)),
+            background: Some(iced::Background::Color(BACKGROUND_COLOR)),
             border: Default::default(),
             shadow: Default::default(),
         })

--- a/src/client/gui/bb_tab/settings.rs
+++ b/src/client/gui/bb_tab/settings.rs
@@ -1,6 +1,6 @@
 use crate::client::gui::app::App;
 use crate::client::gui::bb_theme::color;
-use crate::client::gui::bb_theme::color::TEXT_COLOR;
+use crate::client::gui::bb_theme::color::{BACKGROUND_COLOR, TEXT_COLOR};
 use crate::client::gui::bb_theme::combo_box::{create_menu_style, create_text_input_style};
 use crate::client::gui::bb_theme::container::{
     ContainerStyle, DEFAULT_TEXT_CONTAINER_PADDING, create_container_style,
@@ -181,7 +181,10 @@ fn edit_user_info_column(app: &App) -> Column<SettingsMessage> {
     )
     .font(FIRA_SANS_EXTRABOLD)
     .width(SETTINGS_TEXT_INPUT_WIDTH)
-    .input_style(create_text_input_style(&app.mascot_manager.selected_mascot))
+    .input_style(create_text_input_style(
+        &app.mascot_manager.selected_mascot,
+        BACKGROUND_COLOR,
+    ))
     .menu_style(create_menu_style(&app.mascot_manager.selected_mascot));
 
     let height_text_input = text_input("Enter your height in cm", &pending_info_strings.height)
@@ -204,7 +207,10 @@ fn edit_user_info_column(app: &App) -> Column<SettingsMessage> {
     )
     .font(FIRA_SANS_EXTRABOLD)
     .width(SETTINGS_TEXT_INPUT_WIDTH)
-    .input_style(create_text_input_style(&app.mascot_manager.selected_mascot))
+    .input_style(create_text_input_style(
+        &app.mascot_manager.selected_mascot,
+        BACKGROUND_COLOR,
+    ))
     .menu_style(create_menu_style(&app.mascot_manager.selected_mascot))
     .into();
 
@@ -232,7 +238,10 @@ fn edit_user_info_column(app: &App) -> Column<SettingsMessage> {
 
     for (description_text, mut text_input) in text_input_data_fields {
         text_input = text_input
-            .style(create_text_input_style(&app.mascot_manager.selected_mascot))
+            .style(create_text_input_style(
+                &app.mascot_manager.selected_mascot,
+                BACKGROUND_COLOR,
+            ))
             .font(FIRA_SANS_EXTRABOLD)
             .width(SETTINGS_TEXT_INPUT_WIDTH);
         user_data_column = user_data_column.push(descriptor_space_fill_element_row(

--- a/src/client/gui/bb_tab/workout_creation.rs
+++ b/src/client/gui/bb_tab/workout_creation.rs
@@ -2,8 +2,11 @@ use crate::client::backend::exercise_create::ExerciseCreate;
 use crate::client::backend::pop_up_manager::PopUpType;
 use crate::client::gui::app::App;
 use crate::client::gui::bb_tab::tab::Tab;
+use crate::client::gui::bb_theme::color::{BACKGROUND_COLOR, CONTAINER_COLOR};
 use crate::client::gui::bb_theme::combo_box::{create_menu_style, create_text_input_style};
-use crate::client::gui::bb_theme::container::{ContainerStyle, create_container_style};
+use crate::client::gui::bb_theme::container::{
+    ContainerStyle, DEFAULT_CONTAINER_RADIUS, create_container_style,
+};
 use crate::client::gui::bb_theme::custom_button::{ButtonStyle, create_element_button};
 use crate::client::gui::bb_theme::text_format::{
     FIRA_SANS_EXTRABOLD, format_button_text, format_description_text,
@@ -316,7 +319,7 @@ pub fn view_exercise_edit<'a>(
         counter += 1;
     }
 
-    let new_set_text = format_button_text(text("+")).size(30).center();
+    let new_set_text = format_button_text(text("+")).size(23).center();
 
     let new_set_text_centered = container(new_set_text).center_x(Fill);
 
@@ -324,9 +327,10 @@ pub fn view_exercise_edit<'a>(
         &app.mascot_manager.selected_mascot,
         new_set_text_centered.into(),
         ButtonStyle::ActiveTab,
-        None,
+        Some(DEFAULT_CONTAINER_RADIUS.into()),
     )
     .width(Fill)
+    .height(40)
     .on_press(Message::WorkoutCreation(WorkoutCreationMessage::AddSet))
     .into();
 
@@ -467,7 +471,7 @@ pub fn view_set_no_edit(set: &StrengthSet, number: SetNumber) -> Element<Message
         .push(kg)
         .push(reps)
         .spacing(10)
-        .height(30)
+        .height(40)
         .into();
 
     container(set_row)
@@ -490,25 +494,33 @@ pub fn view_set_edit(number: SetNumber, app: &App) -> Element<Message> {
     if let Some(exercise_string) = &app.exercise_manager.exercise_in_edit_strings {
         kg = container(
             text_input("Enter weight...", &exercise_string.sets[number - 1].kg)
-                .style(create_text_input_style(&app.mascot_manager.selected_mascot))
+                .style(create_text_input_style(
+                    &app.mascot_manager.selected_mascot,
+                    CONTAINER_COLOR,
+                ))
                 .font(FIRA_SANS_EXTRABOLD)
                 .on_input(move |new_kg| -> Message {
                     Message::WorkoutCreation(WorkoutCreationMessage::EditKg(number, new_kg))
                 })
                 .align_x(Alignment::Center)
-                .width(60),
+                .width(60)
+                .line_height(LineHeight::Absolute(20.into())),
         )
         .center(FillPortion(1))
         .into();
         reps = container(
             text_input("Enter reps...", &exercise_string.sets[number - 1].reps)
-                .style(create_text_input_style(&app.mascot_manager.selected_mascot))
+                .style(create_text_input_style(
+                    &app.mascot_manager.selected_mascot,
+                    CONTAINER_COLOR,
+                ))
                 .font(FIRA_SANS_EXTRABOLD)
                 .on_input(move |new_reps| -> Message {
                     Message::WorkoutCreation(WorkoutCreationMessage::EditReps(number, new_reps))
                 })
                 .align_x(Alignment::Center)
-                .width(60),
+                .width(60)
+                .line_height(LineHeight::Absolute(20.into())),
         )
         .center(FillPortion(1))
         .into();
@@ -535,7 +547,7 @@ pub fn view_set_edit(number: SetNumber, app: &App) -> Element<Message> {
             .push(kg)
             .push(reps)
             .spacing(10)
-            .height(30),
+            .height(40),
         Row::new()
             .push(Space::with_width(FillPortion(15)))
             .push(delete_button)
@@ -579,6 +591,7 @@ impl App {
         .menu_style(create_menu_style(&self.mascot_manager.selected_mascot))
         .input_style(create_text_input_style(
             &self.mascot_manager.selected_mascot,
+            BACKGROUND_COLOR,
         ))
         .font(FIRA_SANS_EXTRABOLD)
         .line_height(LineHeight::Absolute(Pixels(30.0)))

--- a/src/client/gui/bb_theme/combo_box.rs
+++ b/src/client/gui/bb_theme/combo_box.rs
@@ -7,11 +7,14 @@ use crate::common::mascot_mod::mascot_trait::MascotTrait;
 use iced::overlay::menu;
 use iced::widget::text_input::Status;
 use iced::widget::{combo_box, text_input};
-use iced_core::{Background, Border, Theme};
+use iced_core::{Background, Border, Color, Theme};
 
-pub fn create_text_input_style(mascot: &Mascot) -> impl Fn(&Theme, Status) -> text_input::Style {
-    |_theme: &Theme, _status: Status| text_input::Style {
-        background: Background::Color(color::BACKGROUND_COLOR),
+pub fn create_text_input_style(
+    mascot: &Mascot,
+    background_color: Color,
+) -> impl Fn(&Theme, Status) -> text_input::Style {
+    move |_theme: &Theme, _status: Status| text_input::Style {
+        background: Background::Color(background_color),
         border: Border {
             color: Default::default(),
             width: 0.0,

--- a/src/client/gui/bb_widget/chart.rs
+++ b/src/client/gui/bb_widget/chart.rs
@@ -1,5 +1,6 @@
 use crate::client::gui::app::App;
 use crate::client::gui::bb_theme;
+use crate::client::gui::bb_theme::color::BACKGROUND_COLOR;
 use crate::client::gui::bb_theme::container::ContainerStyle;
 use crate::client::gui::bb_theme::custom_button::{
     ButtonStyle, DEFAULT_BUTTON_RADIUS, create_text_button,
@@ -53,6 +54,7 @@ pub fn chart_environment_widget<'a>(app: &'a App) -> Element<'a, Message> {
     ))
     .input_style(bb_theme::combo_box::create_text_input_style(
         &app.mascot_manager.selected_mascot,
+        BACKGROUND_COLOR,
     ))
     .font(text_format::FIRA_SANS_EXTRABOLD)
     .width(Length::Fixed(250.0))


### PR DESCRIPTION
<img width="1165" height="810" alt="image" src="https://github.com/user-attachments/assets/6b366ccb-f644-44bf-b7ea-3b853cec171f" />

-text inputs are now a bit brighter to better match the theme
-add set button is now the same height as a set

-workout now stays if you go to another tab